### PR TITLE
Suspense opt-out

### DIFF
--- a/src/resource/AsyncResource.ts
+++ b/src/resource/AsyncResource.ts
@@ -1,5 +1,10 @@
 import { emptyValue, EventualValue, setValue } from "../lib/EventualValue.js";
-import { AsyncLoader, AsyncResourceState } from "./types.js";
+import {
+  AsyncLoader,
+  AsyncResourceState,
+  UseWatchResourceOptions,
+  UseWatchResourceResult,
+} from "./types.js";
 import { Duration, DurationLikeObject } from "luxon";
 import { ObservableValue } from "../observable-value/ObservableValue.js";
 import { useWatchResourceValue } from "./useWatchResourceValue.js";
@@ -94,8 +99,10 @@ export class AsyncResource<T = unknown> {
     }
   }
 
-  public watch(): T {
-    return useWatchResourceValue(this);
+  public watch<TOptions extends UseWatchResourceOptions>(
+    options: TOptions = {} as TOptions,
+  ): UseWatchResourceResult<T, TOptions> {
+    return useWatchResourceValue(this, options);
   }
 
   public watchState(): AsyncResourceState {

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -1,5 +1,6 @@
-import { UseWatchResourceOptions } from "./useWatchResourceValue.js";
 import { Tags } from "../store/types.js";
+import { DurationLikeObject } from "luxon";
+import { EventualValue } from "../lib/EventualValue.js";
 
 export type AsyncLoader<TResult = unknown> = () => Promise<TResult>;
 
@@ -15,3 +16,15 @@ export interface GetAsyncResourceOptions extends UseWatchResourceOptions {
   loaderId?: string;
   tags?: Tags;
 }
+
+export interface UseWatchResourceOptions {
+  keepValueWhileLoading?: boolean;
+  autoRefresh?: DurationLikeObject;
+  useSuspense?: boolean;
+}
+
+export type UseWatchResourceResult<TResult, TOptions> = TOptions extends {
+  useSuspense: false;
+}
+  ? EventualValue<TResult>
+  : TResult;

--- a/src/use-promise/usePromise.ts
+++ b/src/use-promise/usePromise.ts
@@ -1,8 +1,19 @@
-import { AsyncFn, GetAsyncResourceOptions } from "../resource/types.js";
+import {
+  AsyncFn,
+  GetAsyncResourceOptions,
+  UseWatchResourceResult,
+} from "../resource/types.js";
 import { getAsyncResource } from "../resource/getAsyncResource.js";
 
-export const usePromise = <TResult, TArgs extends unknown[]>(
+export const usePromise = <
+  TResult,
+  TArgs extends unknown[],
+  TOptions extends GetAsyncResourceOptions,
+>(
   asyncLoader: AsyncFn<TResult, TArgs>,
   parameters: TArgs,
-  options: GetAsyncResourceOptions = {},
-): TResult => getAsyncResource(asyncLoader, parameters, options).watch();
+  options: TOptions = {} as TOptions,
+): UseWatchResourceResult<TResult, TOptions> =>
+  getAsyncResource(asyncLoader, parameters, options).watch(
+    options,
+  ) as UseWatchResourceResult<TResult, TOptions>;

--- a/test-d/AsyncResource.ts
+++ b/test-d/AsyncResource.ts
@@ -1,5 +1,5 @@
 import { expectAssignable, expectError } from "tsd";
-import { AsyncResource } from "../dist-cjs/resource/AsyncResource.js";
+import { AsyncResource } from "../dist/resource/AsyncResource.js";
 
 function testResultOfWatchMatchesAsyncLoaderReturnType() {
   interface ResultType {

--- a/test-d/usePromise.ts
+++ b/test-d/usePromise.ts
@@ -1,23 +1,35 @@
 import { expectAssignable, expectError } from "tsd";
-import { AsyncLoader } from "../dist-cjs/resource/types.js";
-import { usePromise } from "../dist-cjs/index.js";
+import { AsyncLoader } from "../dist/resource/types.js";
+import { usePromise } from "../dist/index.js";
+import { EventualValue } from "../dist/lib/EventualValue.js";
+
+interface ResultType {
+  foo: number;
+  bar: boolean;
+}
+
+declare const loader: AsyncLoader<ResultType>;
 
 function testResultOfUsePromiseMatchesAsyncLoaderReturnType() {
-  interface ResultType {
-    foo: number;
-    bar: boolean;
-  }
-
-  const loader = {} as AsyncLoader<ResultType>;
   const result = usePromise(loader, []);
   expectAssignable<ResultType>(result);
   expectError(result.unknownProp);
 }
 
+function testResultOfUsePromiseMatchesAsyncLoaderReturnTypeWithDisabledSuspense() {
+  const result = usePromise(loader, [], {
+    useSuspense: false,
+  });
+  expectAssignable<EventualValue<ResultType>>(result);
+}
+
 function testParametersOfUsePromiseMatchingAsyncLoaderParameters() {
-  type AsyncLoader = (foo: number, bar: string) => Promise<unknown>;
-  expectError(usePromise({} as AsyncLoader, []));
-  expectError(usePromise({} as AsyncLoader, ["foo"]));
-  expectError(usePromise({} as AsyncLoader, [42, 42]));
-  usePromise({} as AsyncLoader, [42, "bar"]);
+  type TestAsyncLoader = (foo: number, bar: string) => Promise<unknown>;
+  const testAsyncLoader = {} as TestAsyncLoader;
+
+  expectError(usePromise(testAsyncLoader, []));
+  expectError(usePromise(testAsyncLoader, ["foo"]));
+  expectError(usePromise(testAsyncLoader, [42, 42]));
+
+  usePromise(testAsyncLoader, [42, "bar"]);
 }


### PR DESCRIPTION
This PR introduces an option to opt-out the suspense-based loading behavior. When suspense is disabled, calling `.watch()`  resp. `usePromise()` will not trigger any `<Suspense />` component. Instead an eventual value is returned, meaning you have to check if the value has loaded, before you can access it.

```typescript 
type EventualValue<T> = { isSet: true; value: T } | { isSet: false };
```

Example of how the opt-out behaves:

```tsx
const message = usePromise(loadMessage, ["message-id"], { useSuspense: false });

if (!message.isSet) {
  return <LoadingView />;
}

return <MessageView message={message.value} />;
```