### PR TITLE
Fix incorrect option types for getAsyncResource

### DIFF
--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -12,14 +12,14 @@ export type AnyAsyncFn = AsyncFn<unknown, any[]>; // eslint-disable-line @typesc
 
 export type AsyncResourceState = "void" | "loading" | "loaded" | "error";
 
-export interface GetAsyncResourceOptions extends UseWatchResourceOptions {
+export interface GetAsyncResourceOptions {
   loaderId?: string;
   tags?: Tags;
+  autoRefresh?: DurationLikeObject;
 }
 
-export interface UseWatchResourceOptions {
+export interface UseWatchResourceOptions extends GetAsyncResourceOptions {
   keepValueWhileLoading?: boolean;
-  autoRefresh?: DurationLikeObject;
   useSuspense?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,3 +4,4 @@ export { EventualValue } from "./lib/EventualValue.js";
 export * from "./resource/types.js";
 export * from "./observable-value/types.js";
 export * from "./store/types.js";
+export * from "./use-promise/types.js";

--- a/src/use-promise/types.ts
+++ b/src/use-promise/types.ts
@@ -1,0 +1,7 @@
+import {
+  GetAsyncResourceOptions,
+  UseWatchResourceOptions,
+} from "../resource/types.js";
+
+export type UsePromiseOptions = GetAsyncResourceOptions &
+  UseWatchResourceOptions;

--- a/src/use-promise/usePromise.ts
+++ b/src/use-promise/usePromise.ts
@@ -1,14 +1,11 @@
-import {
-  AsyncFn,
-  GetAsyncResourceOptions,
-  UseWatchResourceResult,
-} from "../resource/types.js";
+import { AsyncFn, UseWatchResourceResult } from "../resource/types.js";
 import { getAsyncResource } from "../resource/getAsyncResource.js";
+import { UsePromiseOptions } from "./types.js";
 
 export const usePromise = <
   TResult,
   TArgs extends unknown[],
-  TOptions extends GetAsyncResourceOptions,
+  TOptions extends UsePromiseOptions,
 >(
   asyncLoader: AsyncFn<TResult, TArgs>,
   parameters: TArgs,


### PR DESCRIPTION
The option type of `getAsyncResource` offers more setting than are actually being used. This PR fixes the type.