### PR TITLE
Fix watched value not updating on resource change

### DIFF
--- a/src/observable-value/useWatchObservableValue.test.tsx
+++ b/src/observable-value/useWatchObservableValue.test.tsx
@@ -38,3 +38,12 @@ test("unbinds observer on unmount", async () => {
   dom.rerender(<></>);
   expect(v.observerCount).toBe(0);
 });
+
+test("updates value when observable instance changes", async () => {
+  const v1 = new ObservableValue("foo");
+  const v2 = new ObservableValue("bar");
+  const dom = render(<TestComponent value={v1} />);
+  screen.getByText("foo");
+  dom.rerender(<TestComponent value={v2} />);
+  screen.getByText("bar");
+});

--- a/src/observable-value/useWatchObservableValue.ts
+++ b/src/observable-value/useWatchObservableValue.ts
@@ -5,6 +5,11 @@ export const useWatchObservableValue = <T>(
   observable: ObservableValue<T>,
 ): T => {
   const [watchedValue, setWatchedValue] = useState(observable.value);
-  useEffect(() => observable.observe(setWatchedValue));
+
+  useEffect(() => {
+    setWatchedValue(observable.value);
+    return observable.observe(setWatchedValue);
+  }, [observable]);
+
   return watchedValue;
 };


### PR DESCRIPTION
When a resource is watched in any component and the resource is replaced by another resource, it does not update correctly. See the appended unit test for detail. This critical bug is fixed by this PR.