### PR TITLE
Improve the result object when not using suspense

### DIFF
--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -1,6 +1,5 @@
 import { Tags } from "../store/types.js";
 import { DurationLikeObject } from "luxon";
-import { EventualValue } from "../lib/EventualValue.js";
 
 export type AsyncLoader<TResult = unknown> = () => Promise<TResult>;
 
@@ -23,8 +22,23 @@ export interface UseWatchResourceOptions extends GetAsyncResourceOptions {
   useSuspense?: boolean;
 }
 
+export type NoSuspenseReturnType<T> = Readonly<
+  {
+    maybeValue: T | undefined;
+    isLoading: boolean;
+  } & (
+    | {
+        hasValue: false;
+      }
+    | {
+        hasValue: true;
+        value: T;
+      }
+  )
+>;
+
 export type UseWatchResourceResult<TResult, TOptions> = TOptions extends {
   useSuspense: false;
 }
-  ? EventualValue<TResult>
+  ? NoSuspenseReturnType<TResult>
   : TResult;

--- a/test-d/usePromise.ts
+++ b/test-d/usePromise.ts
@@ -1,7 +1,7 @@
 import { expectAssignable, expectError } from "tsd";
 import { AsyncLoader } from "../dist/resource/types.js";
 import { usePromise } from "../dist/index.js";
-import { EventualValue } from "../dist/lib/EventualValue.js";
+import { NoSuspenseReturnType } from "../dist-cjs/resource/types.js";
 
 interface ResultType {
   foo: number;
@@ -20,7 +20,7 @@ function testResultOfUsePromiseMatchesAsyncLoaderReturnTypeWithDisabledSuspense(
   const result = usePromise(loader, [], {
     useSuspense: false,
   });
-  expectAssignable<EventualValue<ResultType>>(result);
+  expectAssignable<NoSuspenseReturnType<ResultType>>(result);
 }
 
 function testParametersOfUsePromiseMatchingAsyncLoaderParameters() {


### PR DESCRIPTION
This PR adds some more properties to the result object when not using suspense. The new properties will help to get more insights in the resources loading state.