### PR TITLE
Allow opt-out loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ coverage/
 .idea/runConfigurations
 .eslintcache
 .idea/php.xml
+.idea/GitLink.xml

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ const App = () => {
 - Type-Safe API
 - No "double-loading" when using "same" Promise in different places in your app
 - Caching with support for [custom tags](#tags-1)
+- [Opt-out Suspense-based loading](#opt-out-suspense)
 - [Cache invalidation](#refreshing-resources) with
   [glob support](#hierarchical-tags)
 - [Observable loading state](#watchstate)
@@ -88,6 +89,8 @@ const App = () => {
 - [Refreshing resources](#refreshing-resources)
 - [Lazy loading with Async Resources](#-lazy-loading-with-async-resources)
 - [Defining loading views](#defining-loading-views)
+- [Opt-Out Suspense](#opt-out-suspense)
+- [Opt-Out Loading](#opt-out-loading)
 - [Error handling](#error-handling)
 - [Best practices](#best-practices)
 
@@ -906,6 +909,38 @@ Examples of result objects:
   value: "Foo",
   hasValue: true,
 });
+```
+
+## Opt-Out Loading
+
+You probably know that you should
+[not call hooks conditionally](https://react.dev/warnings/invalid-hook-call-warning#breaking-rules-of-hooks).
+But what if the loader parameters you want to use e.g. in `usePromise` are
+optional properties, and the loader function requires them? In this case just
+use `null` as parameters and loading is disabled!
+
+😈 Bad:
+
+```jsx
+const Username = ({ id }) => {
+  if (!id) {
+    return null;
+  }
+  // 💥 This will throw a React error because `usePromise` is called conditionally!
+  const user = usePromise(loadUseProfile, [id]).watch();
+  return <>{user.name}</>;
+};
+```
+
+😇 Good:
+
+```jsx
+const Username = ({ id }) => {
+  // When required loader parameters can be undefined: use null 👇
+  const user = usePromise(loadUseProfile, id ? [id] : null).watch();
+  // ⚠️ In this case, `user` can also be `undefined`!
+  return <>{user ? user.name : "Unknown"}</>;
+};
 ```
 
 ## Error handling

--- a/src/lib/testing.tsx
+++ b/src/lib/testing.tsx
@@ -1,8 +1,6 @@
 import React, { createElement, FC, ReactNode, Suspense } from "react";
 
-export const sleep = (ms: number) => {
-  return new Promise((res) => setTimeout(res, ms));
-};
+export const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
 export const squareAsync = async (value: number, sleepTimeMs: number) => {
   await sleep(sleepTimeMs);

--- a/src/resource/AsyncResource.test.ts
+++ b/src/resource/AsyncResource.test.ts
@@ -1,10 +1,7 @@
 import { beforeEach, jest } from "@jest/globals";
 import { AsyncLoader } from "./types.js";
 import { AsyncResource } from "./AsyncResource.js";
-
-const sleep = (ms: number) => {
-  return new Promise((res) => setTimeout(res, ms));
-};
+import { sleep } from "../lib/testing.js";
 
 let loaderCalls = 0;
 let sleepTime: jest.Mock<() => number>;
@@ -44,18 +41,18 @@ describe("calling load()", () => {
   test("triggers loader", async () => {
     const resource = new AsyncResource(loader);
     expect(loader).toHaveBeenCalledTimes(0);
-    resource.load();
+    void resource.load();
     expect(loader).toHaveBeenCalledTimes(1);
   });
 
   test("twice does not trigger loader twice", async () => {
     const resource = new AsyncResource(loader);
     // load
-    resource.load();
+    void resource.load();
     expect(loader).toHaveBeenCalledTimes(1);
     // after 100ms load again
     await jest.advanceTimersByTimeAsync(loadingTime / 2);
-    resource.load();
+    void resource.load();
     expect(loader).toHaveBeenCalledTimes(1);
     // wait for second load
     await jest.advanceTimersByTimeAsync(loadingTime);
@@ -67,17 +64,17 @@ describe("calling load()", () => {
       ttl: { milliseconds: 100 },
     });
     // load
-    resource.load();
+    void resource.load();
     expect(loader).toHaveBeenCalledTimes(1);
     // wait for load
     await jest.advanceTimersByTimeAsync(loadingTime);
     // wait for TTL-1 -> not loading again
     await jest.advanceTimersByTimeAsync(99);
-    resource.load();
+    void resource.load();
     expect(loader).toHaveBeenCalledTimes(1);
     // wait for TTL rest -> loading again
     await jest.advanceTimersByTimeAsync(1);
-    resource.load();
+    void resource.load();
     expect(loader).toHaveBeenCalledTimes(2);
   });
 
@@ -85,13 +82,13 @@ describe("calling load()", () => {
     const resource = new AsyncResource(loader);
     // #1 load for 50ms
     sleepTime.mockReturnValue(50);
-    resource.load();
+    void resource.load();
     // after 10ms clear
     await jest.advanceTimersByTimeAsync(10);
-    resource.refresh();
+    void resource.refresh();
     // 2# load for 20ms
     sleepTime.mockReturnValue(20);
-    resource.load();
+    void resource.load();
     // wait for second load
     await jest.advanceTimersByTimeAsync(20);
     if (!resource.value.value.isSet) {
@@ -103,7 +100,7 @@ describe("calling load()", () => {
   test("will be aborted if cleared during loading", async () => {
     const resource = new AsyncResource(loader);
     // load
-    resource.load();
+    void resource.load();
     // while still loading
     await jest.advanceTimersByTimeAsync(loadingTime / 2);
     resource.refresh();
@@ -122,7 +119,7 @@ describe(".value", () => {
   test("is set after loader is done", async () => {
     const resource = new AsyncResource(loader);
     // load
-    resource.load();
+    void resource.load();
     // wait for load
     await jest.advanceTimersByTimeAsync(loadingTime);
     if (!resource.value.value.isSet) {
@@ -134,7 +131,7 @@ describe(".value", () => {
   test("is empty after clear()", async () => {
     const resource = new AsyncResource(loader);
     // load
-    resource.load();
+    void resource.load();
     // wait for load
     await jest.advanceTimersByTimeAsync(loadingTime);
     resource.refresh();
@@ -148,7 +145,7 @@ describe(".value", () => {
       },
     });
     // load
-    resource.load();
+    void resource.load();
     // wait for load
     await jest.advanceTimersByTimeAsync(loadingTime);
     expect(resource.value.value.isSet).toBe(true);
@@ -160,12 +157,12 @@ describe(".value", () => {
   test("is updated after loading again when cleared", async () => {
     const resource = new AsyncResource(loader);
     // load
-    resource.load();
+    void resource.load();
     // wait for load
     await jest.advanceTimersByTimeAsync(loadingTime);
     resource.refresh();
     // load again for 1000ms
-    resource.load();
+    void resource.load();
     // wait for load
     await jest.advanceTimersByTimeAsync(loadingTime);
     if (!resource.value.value.isSet) {
@@ -184,7 +181,7 @@ describe(".error", () => {
   test("is set after loader throws error", async () => {
     const resource = new AsyncResource(errorLoader);
     // load
-    resource.load();
+    void resource.load();
     // wait for load
     await jest.advanceTimersByTimeAsync(loadingTime);
     if (!resource.error.value.isSet) {
@@ -196,7 +193,7 @@ describe(".error", () => {
   test("is empty after clear()", async () => {
     const resource = new AsyncResource(errorLoader);
     // load
-    resource.load();
+    void resource.load();
     // wait for load
     await jest.advanceTimersByTimeAsync(loadingTime);
     resource.refresh();
@@ -210,7 +207,7 @@ describe(".error", () => {
       },
     });
     // load
-    resource.load();
+    void resource.load();
     // wait for load
     await jest.advanceTimersByTimeAsync(loadingTime);
     expect(resource.error.value.isSet).toBe(true);
@@ -222,13 +219,13 @@ describe(".error", () => {
   test("is updated after loading again when cleared", async () => {
     const resource = new AsyncResource(errorLoader);
     // load
-    resource.load();
+    void resource.load();
     // wait for load
     await jest.advanceTimersByTimeAsync(loadingTime);
     resource.refresh();
     errorLoader.mockImplementation(loaderImpl);
     // load again (now without error)
-    resource.load();
+    void resource.load();
     // wait for load
     await jest.advanceTimersByTimeAsync(loadingTime);
     if (!resource.value.value.isSet) {
@@ -248,7 +245,7 @@ test("TTL is 'restarted' on reload", async () => {
   });
 
   // load
-  resource.load();
+  void resource.load();
   // wait for load
   await jest.advanceTimersByTimeAsync(loadingTime);
   // wait for TTL/2
@@ -256,7 +253,7 @@ test("TTL is 'restarted' on reload", async () => {
   // reload resource
   resource.refresh();
   // load
-  resource.load();
+  void resource.load();
   // wait for load
   await jest.advanceTimersByTimeAsync(loadingTime);
   // wait for TTL/2 -> resource not cleared

--- a/src/resource/AsyncResource.ts
+++ b/src/resource/AsyncResource.ts
@@ -40,7 +40,7 @@ export class AsyncResource<T = unknown> {
     this.state.updateValue("void");
   }
 
-  public load(): void {
+  public async load(): Promise<void> {
     if (this.value.value.isSet || this.error.value.isSet) {
       return;
     }
@@ -48,6 +48,7 @@ export class AsyncResource<T = unknown> {
     if (this.loaderPromise === undefined) {
       this.loaderPromise = this.handleLoading();
     }
+    return this.loaderPromise;
   }
 
   public isMatchingError(error: true | unknown): boolean {

--- a/src/resource/getAsyncResource.test.ts
+++ b/src/resource/getAsyncResource.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, expect, jest, test } from "@jest/globals";
+import { sleep } from "../lib/testing.js";
+import { getAsyncResource } from "./getAsyncResource.js";
+import { Store } from "../store/Store.js";
+import { AsyncResource } from "./AsyncResource.js";
+
+const sleepTime = 2000;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  Store.default.clear();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+const loader = jest.fn(async (value: string): Promise<string> => {
+  await sleep(sleepTime);
+  return value;
+});
+
+const load = async (resource: AsyncResource): Promise<void> => {
+  const loadingPromise = resource.load();
+  jest.advanceTimersToNextTimer();
+  await loadingPromise;
+};
+
+test("Expect loader is not called when parameters is null", async () => {
+  const resource = getAsyncResource(loader, null);
+  await load(resource);
+  expect(loader).not.toBeCalled();
+});
+
+test("Expect value is undefined when parameters is null", async () => {
+  const resource = getAsyncResource(loader, null);
+  await load(resource);
+
+  const value = resource.value.value.isSet
+    ? resource.value.value.value
+    : undefined;
+
+  expect(resource.value.value.isSet).toBe(true);
+  expect(value).toBe(undefined);
+});

--- a/src/resource/resourceify.ts
+++ b/src/resource/resourceify.ts
@@ -1,11 +1,22 @@
-import { AsyncFn, GetAsyncResourceOptions } from "./types.js";
+import {
+  AsyncFn,
+  FnParameters,
+  GetAsyncResourceOptions,
+  NullableResourceValue,
+} from "./types.js";
 import { AsyncResource } from "./AsyncResource.js";
 import { getAsyncResource } from "./getAsyncResource.js";
 
 export const resourceify =
-  <TResult, TArgs extends unknown[]>(asyncFn: AsyncFn<TResult, TArgs>) =>
+  <
+    TValue,
+    TParams extends FnParameters,
+    TNullableParams extends TParams | null,
+  >(
+    asyncFn: AsyncFn<TValue, TParams>,
+  ) =>
   (
-    parameters: TArgs,
+    parameters: TNullableParams,
     options?: GetAsyncResourceOptions,
-  ): AsyncResource<TResult> =>
+  ): AsyncResource<NullableResourceValue<TValue, TParams, TNullableParams>> =>
     getAsyncResource(asyncFn, parameters, options);

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -1,13 +1,23 @@
 import { Tags } from "../store/types.js";
 import { DurationLikeObject } from "luxon";
 
-export type AsyncLoader<TResult = unknown> = () => Promise<TResult>;
+// Async function types
+export type FnParameters = unknown[];
 
-export type AsyncFn<TResult, TArgs extends unknown[]> = (
-  ...args: TArgs
+export type NullableResourceValue<
+  TValue,
+  TParams extends FnParameters,
+  TNullableParams extends TParams | null,
+> = TParams extends TNullableParams ? TValue : TValue | undefined;
+
+export type AsyncFn<TResult, TParams extends FnParameters> = (
+  ...args: TParams
 ) => Promise<TResult>;
 
 export type AnyAsyncFn = AsyncFn<unknown, any[]>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+// Async resource types
+export type AsyncLoader<TResult = unknown> = () => Promise<TResult>;
 
 export type AsyncResourceState = "void" | "loading" | "loaded" | "error";
 
@@ -17,6 +27,7 @@ export interface GetAsyncResourceOptions {
   autoRefresh?: DurationLikeObject;
 }
 
+// useWatchResource types
 export interface UseWatchResourceOptions extends GetAsyncResourceOptions {
   keepValueWhileLoading?: boolean;
   useSuspense?: boolean;
@@ -37,8 +48,8 @@ export type NoSuspenseReturnType<T> = Readonly<
   )
 >;
 
-export type UseWatchResourceResult<TResult, TOptions> = TOptions extends {
+export type UseWatchResourceResult<TValue, TOptions> = TOptions extends {
   useSuspense: false;
 }
-  ? NoSuspenseReturnType<TResult>
-  : TResult;
+  ? NoSuspenseReturnType<TValue>
+  : TValue;

--- a/src/resource/useWatchResourceValue.ts
+++ b/src/resource/useWatchResourceValue.ts
@@ -18,7 +18,7 @@ export const useWatchResourceValue = <
   const error = useWatchObservableValue(resource.error);
   const previousValue = useRef(observedValue);
 
-  resource.load();
+  void resource.load();
 
   if (observedValue.isSet) {
     previousValue.current = observedValue;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,5 +1,5 @@
 import { AsyncResource } from "../resource/AsyncResource.js";
-import { AnyAsyncFn } from "../resource/types.js";
+import { AnyAsyncFn, FnParameters } from "../resource/types.js";
 
 export type Tag = string;
 export type TagPattern = string;
@@ -16,7 +16,7 @@ export interface StorageEntry {
 
 interface StorageKeyBuilderInput {
   asyncFn: AnyAsyncFn;
-  parameters: unknown[];
+  parameters: FnParameters;
   loaderId?: string;
 }
 

--- a/src/use-promise/usePromise.ts
+++ b/src/use-promise/usePromise.ts
@@ -1,16 +1,25 @@
-import { AsyncFn, UseWatchResourceResult } from "../resource/types.js";
+import {
+  AsyncFn,
+  FnParameters,
+  NullableResourceValue,
+  UseWatchResourceResult,
+} from "../resource/types.js";
 import { getAsyncResource } from "../resource/getAsyncResource.js";
 import { UsePromiseOptions } from "./types.js";
 
 export const usePromise = <
-  TResult,
-  TArgs extends unknown[],
+  TValue,
+  TParams extends FnParameters,
+  TNullableParams extends TParams | null,
   TOptions extends UsePromiseOptions,
 >(
-  asyncLoader: AsyncFn<TResult, TArgs>,
-  parameters: TArgs,
+  asyncLoader: AsyncFn<TValue, TParams>,
+  parameters: TNullableParams,
   options: TOptions = {} as TOptions,
-): UseWatchResourceResult<TResult, TOptions> =>
+): UseWatchResourceResult<
+  NullableResourceValue<TValue, TParams, TNullableParams>,
+  TOptions
+> =>
   getAsyncResource(asyncLoader, parameters, options).watch(
     options,
-  ) as UseWatchResourceResult<TResult, TOptions>;
+  ) as UseWatchResourceResult<TValue, TOptions>;

--- a/test-d/EventualValue.ts
+++ b/test-d/EventualValue.ts
@@ -1,22 +1,22 @@
 import { emptyValue, EventualValue, setValue } from "../dist/lib/EventualValue";
-import { expectAssignable, expectError } from "tsd";
+import { expectError, expectType } from "tsd";
 
 function testAccessingValuePropertyNeedsCheckOfIsSet() {
   const testValue = {} as EventualValue<number>;
 
   if (testValue.isSet) {
-    expectAssignable<number>(testValue.value);
+    expectType<number>(testValue.value);
   } else {
     expectError(testValue.value);
   }
 }
 
 function testSetValueFnCreatesWhereValueIsSet() {
-  expectAssignable<number>(setValue(42).value);
-  expectAssignable<true>(setValue(42).isSet);
+  expectType<number>(setValue(42).value);
+  expectType<true>(setValue(42).isSet);
 }
 
 function testEmptyValueConstantIsNotSet() {
   expectError(emptyValue.value);
-  expectAssignable<false>(emptyValue.isSet);
+  expectType<false>(emptyValue.isSet);
 }

--- a/test-d/getAsyncResource.ts
+++ b/test-d/getAsyncResource.ts
@@ -1,0 +1,25 @@
+import { expectError, expectType } from "tsd";
+import { getAsyncResource } from "../dist/index.js";
+import { AsyncFn } from "../dist/resource/types.js";
+
+declare const loader: AsyncFn<number, [boolean, string]>;
+
+function testGetAsyncResourceRequiresCorrectParameters() {
+  getAsyncResource(loader, null);
+  expectError(getAsyncResource(loader, []));
+  expectError(getAsyncResource(loader, [42]));
+  expectError(getAsyncResource(loader, [42, 43]));
+  expectError(getAsyncResource(loader, [true]));
+  getAsyncResource(loader, [true, "foo"]);
+  expectError(getAsyncResource(loader, [true, "foo", 42]));
+}
+
+function testWatchedResultIsLoaderReturnType() {
+  const value = getAsyncResource(loader, [true, "foo"]).watch();
+  expectType<number>(value);
+}
+
+function testWatchedResultIncludesUndefinedWhenParametersIsNull() {
+  const optionalValue = getAsyncResource(loader, null).watch();
+  expectType<number | undefined>(optionalValue);
+}

--- a/test-d/usePromise.ts
+++ b/test-d/usePromise.ts
@@ -1,4 +1,4 @@
-import { expectAssignable, expectError } from "tsd";
+import { expectAssignable, expectError, expectType } from "tsd";
 import { AsyncLoader } from "../dist/resource/types.js";
 import { usePromise } from "../dist/index.js";
 import { NoSuspenseReturnType } from "../dist-cjs/resource/types.js";
@@ -32,4 +32,11 @@ function testParametersOfUsePromiseMatchingAsyncLoaderParameters() {
   expectError(usePromise(testAsyncLoader, [42, 42]));
 
   usePromise(testAsyncLoader, [42, "bar"]);
+}
+
+function testResultTypeIncludeUndefinedWhenParametersAreNull() {
+  type TestAsyncLoader = () => Promise<number>;
+  const testAsyncLoader = {} as TestAsyncLoader;
+  const result = usePromise(testAsyncLoader, null);
+  expectType<number | undefined>(result);
 }


### PR DESCRIPTION
You probably know that you should
[not call hooks conditionally](https://react.dev/warnings/invalid-hook-call-warning#breaking-rules-of-hooks).
But what if the loader parameters you want to use e.g. in `usePromise` are
optional properties, and the loader function requires them? This PR makes it possible to opt-out loading.