### PR TITLE
Fix render-loop on loading opt-out

### DIFF
--- a/src/resource/getAsyncResource.ts
+++ b/src/resource/getAsyncResource.ts
@@ -3,8 +3,9 @@ import { defaultStorageKeyBuilder } from "../store/defaultStorageKeyBuilder.js";
 import { Store } from "../store/Store.js";
 import { AsyncResource, AsyncResourceOptions } from "./AsyncResource.js";
 
-const buildEmptyResource = (options: AsyncResourceOptions) =>
-  new AsyncResource<undefined>(() => Promise.resolve(undefined), options);
+const emptyResource = new AsyncResource<undefined>(() =>
+  Promise.resolve(undefined),
+);
 
 // function overloads for nullable parameters
 export function getAsyncResource<TValue, TParams extends FnParameters>(
@@ -31,7 +32,7 @@ export function getAsyncResource<TValue, TParams extends FnParameters>(
   };
 
   if (parameters === null) {
-    return buildEmptyResource(asyncResourceOptions);
+    return emptyResource;
   }
 
   const storageKey = defaultStorageKeyBuilder({


### PR DESCRIPTION
When using the opt-out options from `usePromise` (by setting loader parameters to `null`) the calling component falls in an endless render loop. This change will fix this issue.