### PR TITLE
Fix autoRefresh option for usePromise

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,7 @@ const userResource = getAsyncResource(getUser, [123]);
 
 // 3. With options
 const userResource = getAsyncResource(getUser, [123], {
-  autoRefresh: {
-    seconds: 30,
-  },
+  tags: ["api"],
 });
 
 // 4. Usage in factory function
@@ -270,14 +268,15 @@ const Score = ({ matchId }) => {
 You can configure `usePromise` and `getAsyncResource` with the following
 options:
 
-#### autoRefresh
+#### autoRefresh (only supported by `usePromise`)
 
 Type:
 [Duration like object](https://moment.github.io/luxon/api-docs/index.html#durationfromobject)\
 Default: `undefined`
 
 When a duration is configured, the resource will automatically be refreshed in
-the provided interval.
+the provided interval. If the same resource has multiple auto-refresh intervals,
+the shortest interval will be used.
 
 ```javascript
 autoRefresh: {
@@ -285,7 +284,7 @@ autoRefresh: {
 }
 ```
 
-#### keepValueWhileLoading
+#### keepValueWhileLoading (only supported by `usePromise`)
 
 Type: `boolean`\
 Default: `true`
@@ -321,7 +320,7 @@ the "same code" issue (see
 ["Caveats of default storage key generation"](#caveats-of-default-storage-key-generation)),
 you can set an explicit loader ID, that identifies the loader function.
 
-#### useSuspense
+#### useSuspense (only supported by `usePromise`)
 
 Type: `boolean`\
 Default: `true`

--- a/src/lib/ConsolidatedTimeout.test.ts
+++ b/src/lib/ConsolidatedTimeout.test.ts
@@ -81,3 +81,10 @@ test("Callback is triggered instantly when adding due timeout while already runn
   timeout.addTimeout({ milliseconds: 500 });
   expect(callback).toHaveBeenCalledTimes(1);
 });
+
+test("Removing last timeout will not trigger callback", (): void => {
+  timeout.start();
+  const removeTimeout = timeout.addTimeout({ milliseconds: 1000 });
+  removeTimeout();
+  testCallbackIsNotCalledAfter(1000);
+});

--- a/src/lib/ConsolidatedTimeout.test.ts
+++ b/src/lib/ConsolidatedTimeout.test.ts
@@ -1,0 +1,95 @@
+import { jest, afterEach, beforeEach } from "@jest/globals";
+import { ConsolidatedTimeout } from "./ConsolidatedTimeout.js";
+
+const callback = jest.fn();
+
+let timeout: ConsolidatedTimeout;
+
+beforeEach((): void => {
+  jest.resetAllMocks();
+  jest.useFakeTimers();
+  timeout = new ConsolidatedTimeout(callback);
+});
+
+afterEach((): void => {
+  timeout.stop();
+});
+
+test("Callback is not triggered after start when there is no timeout added", (): void => {
+  timeout.start();
+  jest.advanceTimersByTime(Number.MAX_SAFE_INTEGER);
+  expect(callback).not.toHaveBeenCalled();
+});
+
+test("Callback is triggered (only once) after timeout added after start", (): void => {
+  timeout.start();
+  timeout.addTimeout({ milliseconds: 1000 });
+
+  jest.advanceTimersByTime(999);
+  expect(callback).toHaveBeenCalledTimes(0);
+
+  jest.advanceTimersByTime(1);
+  expect(callback).toHaveBeenCalledTimes(1);
+
+  jest.advanceTimersByTime(Number.MAX_SAFE_INTEGER);
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+test("Callback is triggered after timeout added before start", (): void => {
+  timeout.addTimeout({ milliseconds: 1000 });
+  timeout.start();
+
+  jest.advanceTimersByTime(999);
+  expect(callback).toHaveBeenCalledTimes(0);
+
+  jest.advanceTimersByTime(1);
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+test("Callback is triggered at minimum timeout", (): void => {
+  timeout.start();
+  timeout.addTimeout({ milliseconds: 1000 });
+  timeout.addTimeout({ milliseconds: 500 });
+
+  jest.advanceTimersByTime(499);
+  expect(callback).toHaveBeenCalledTimes(0);
+
+  jest.advanceTimersByTime(1);
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+test("Consecutive start call restarts the timeout", (): void => {
+  timeout.start();
+  timeout.addTimeout({ milliseconds: 1000 });
+  jest.advanceTimersByTime(999);
+
+  timeout.start();
+  jest.advanceTimersByTime(500);
+  expect(callback).toHaveBeenCalledTimes(0);
+  jest.advanceTimersByTime(500);
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+test("Callback is triggered when adding timeout while already running", (): void => {
+  timeout.start();
+
+  timeout.addTimeout({ milliseconds: 1000 });
+  jest.advanceTimersByTime(499);
+
+  timeout.addTimeout({ milliseconds: 500 });
+  expect(callback).toHaveBeenCalledTimes(0);
+
+  jest.advanceTimersByTime(1);
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+test("Callback is triggered instantly when adding due timeout while already running", (): void => {
+  timeout.start();
+
+  timeout.addTimeout({ milliseconds: 1000 });
+  jest.advanceTimersByTime(501);
+  expect(callback).toHaveBeenCalledTimes(0);
+
+  timeout.addTimeout({ milliseconds: 500 });
+  expect(callback).toHaveBeenCalledTimes(1);
+});

--- a/src/lib/ConsolidatedTimeout.test.ts
+++ b/src/lib/ConsolidatedTimeout.test.ts
@@ -15,81 +15,73 @@ afterEach((): void => {
   timeout.stop();
 });
 
+const testCallbackIsCalledAfter = (ms: number): void => {
+  const beforeCalls = callback.mock.calls.length;
+  jest.advanceTimersByTime(ms - 1);
+  expect(callback).toHaveBeenCalledTimes(beforeCalls);
+  jest.advanceTimersByTime(1);
+  expect(callback).toHaveBeenCalledTimes(beforeCalls + 1);
+};
+
+const testCallbackIsNotCalledAfter = (ms: number): void => {
+  const beforeCalls = callback.mock.calls.length;
+  jest.advanceTimersByTime(ms - 1);
+  expect(callback).toHaveBeenCalledTimes(beforeCalls);
+  jest.advanceTimersByTime(1);
+  expect(callback).toHaveBeenCalledTimes(beforeCalls);
+};
+
 test("Callback is not triggered after start when there is no timeout added", (): void => {
   timeout.start();
-  jest.advanceTimersByTime(Number.MAX_SAFE_INTEGER);
-  expect(callback).not.toHaveBeenCalled();
+  testCallbackIsNotCalledAfter(Number.MAX_SAFE_INTEGER);
 });
 
 test("Callback is triggered (only once) after timeout added after start", (): void => {
   timeout.start();
   timeout.addTimeout({ milliseconds: 1000 });
 
-  jest.advanceTimersByTime(999);
-  expect(callback).toHaveBeenCalledTimes(0);
-
-  jest.advanceTimersByTime(1);
-  expect(callback).toHaveBeenCalledTimes(1);
-
-  jest.advanceTimersByTime(Number.MAX_SAFE_INTEGER);
-  expect(callback).toHaveBeenCalledTimes(1);
+  testCallbackIsCalledAfter(1000);
+  testCallbackIsNotCalledAfter(Number.MAX_SAFE_INTEGER);
 });
 
 test("Callback is triggered after timeout added before start", (): void => {
   timeout.addTimeout({ milliseconds: 1000 });
   timeout.start();
-
-  jest.advanceTimersByTime(999);
-  expect(callback).toHaveBeenCalledTimes(0);
-
-  jest.advanceTimersByTime(1);
-  expect(callback).toHaveBeenCalledTimes(1);
+  testCallbackIsCalledAfter(1000);
 });
 
 test("Callback is triggered at minimum timeout", (): void => {
   timeout.start();
   timeout.addTimeout({ milliseconds: 1000 });
   timeout.addTimeout({ milliseconds: 500 });
-
-  jest.advanceTimersByTime(499);
-  expect(callback).toHaveBeenCalledTimes(0);
-
-  jest.advanceTimersByTime(1);
-  expect(callback).toHaveBeenCalledTimes(1);
+  testCallbackIsCalledAfter(500);
 });
 
 test("Consecutive start call restarts the timeout", (): void => {
   timeout.start();
   timeout.addTimeout({ milliseconds: 1000 });
-  jest.advanceTimersByTime(999);
+  testCallbackIsNotCalledAfter(999);
 
   timeout.start();
-  jest.advanceTimersByTime(500);
-  expect(callback).toHaveBeenCalledTimes(0);
-  jest.advanceTimersByTime(500);
-  expect(callback).toHaveBeenCalledTimes(1);
+  testCallbackIsNotCalledAfter(500);
+  testCallbackIsCalledAfter(500);
 });
 
 test("Callback is triggered when adding timeout while already running", (): void => {
   timeout.start();
 
   timeout.addTimeout({ milliseconds: 1000 });
-  jest.advanceTimersByTime(499);
+  testCallbackIsNotCalledAfter(499);
 
   timeout.addTimeout({ milliseconds: 500 });
-  expect(callback).toHaveBeenCalledTimes(0);
-
-  jest.advanceTimersByTime(1);
-  expect(callback).toHaveBeenCalledTimes(1);
+  testCallbackIsCalledAfter(1);
 });
 
 test("Callback is triggered instantly when adding due timeout while already running", (): void => {
   timeout.start();
 
   timeout.addTimeout({ milliseconds: 1000 });
-  jest.advanceTimersByTime(501);
-  expect(callback).toHaveBeenCalledTimes(0);
-
+  testCallbackIsNotCalledAfter(501);
   timeout.addTimeout({ milliseconds: 500 });
   expect(callback).toHaveBeenCalledTimes(1);
 });

--- a/src/lib/ConsolidatedTimeout.test.ts
+++ b/src/lib/ConsolidatedTimeout.test.ts
@@ -1,4 +1,4 @@
-import { jest, afterEach, beforeEach } from "@jest/globals";
+import { beforeEach, jest } from "@jest/globals";
 import { ConsolidatedTimeout } from "./ConsolidatedTimeout.js";
 
 const callback = jest.fn();
@@ -9,10 +9,6 @@ beforeEach((): void => {
   jest.resetAllMocks();
   jest.useFakeTimers();
   timeout = new ConsolidatedTimeout(callback);
-});
-
-afterEach((): void => {
-  timeout.stop();
 });
 
 const testCallbackIsCalledAfter = (ms: number): void => {

--- a/src/lib/ConsolidatedTimeout.ts
+++ b/src/lib/ConsolidatedTimeout.ts
@@ -1,0 +1,60 @@
+import { DateTime, Duration, DurationLikeObject } from "luxon";
+
+export type RemoveTimeout = () => void;
+type ExecutionCallback = () => void;
+type Timeout = ReturnType<typeof setTimeout>;
+
+export class ConsolidatedTimeout {
+  private readonly callback: ExecutionCallback;
+  private startTime: DateTime;
+  private timeouts = new Set<number>();
+  private runningTimeout?: Timeout;
+
+  public constructor(callback: ExecutionCallback) {
+    this.startTime = DateTime.now();
+    this.callback = callback;
+  }
+
+  public start(): void {
+    this.startTime = DateTime.now();
+    this.startNextTimeout();
+  }
+
+  public stop(): void {
+    if (this.runningTimeout) {
+      clearTimeout(this.runningTimeout);
+      this.runningTimeout = undefined;
+    }
+  }
+
+  public addTimeout(timeout: DurationLikeObject): RemoveTimeout {
+    const timeoutMs = Duration.fromDurationLike(timeout).toMillis();
+
+    this.timeouts.add(timeoutMs);
+    this.startNextTimeout();
+
+    return () => {
+      this.timeouts.delete(timeoutMs);
+    };
+  }
+
+  private startNextTimeout(): void {
+    this.stop();
+
+    if (this.timeouts.size === 0) {
+      return;
+    }
+
+    const shortestTimeout = Math.min(...this.timeouts);
+    const elapsedTime = this.startTime.diffNow().negate().toMillis();
+    const ms = shortestTimeout - elapsedTime;
+
+    if (ms <= 0) {
+      this.callback();
+    } else {
+      this.runningTimeout = setTimeout(() => this.callback(), ms);
+    }
+  }
+}
+
+export default ConsolidatedTimeout;

--- a/src/lib/ConsolidatedTimeout.ts
+++ b/src/lib/ConsolidatedTimeout.ts
@@ -35,6 +35,7 @@ export class ConsolidatedTimeout {
 
     return () => {
       this.timeoutMillis.delete(timeoutMs);
+      this.startNextTimeout();
     };
   }
 

--- a/src/lib/ConsolidatedTimeout.ts
+++ b/src/lib/ConsolidatedTimeout.ts
@@ -20,7 +20,7 @@ export class ConsolidatedTimeout {
     this.startNextTimeout();
   }
 
-  public stop(): void {
+  private clear(): void {
     if (this.runningTimeout) {
       clearTimeout(this.runningTimeout);
       this.runningTimeout = undefined;
@@ -39,7 +39,7 @@ export class ConsolidatedTimeout {
   }
 
   private startNextTimeout(): void {
-    this.stop();
+    this.clear();
 
     if (this.timeouts.size === 0) {
       return;

--- a/src/lib/ConsolidatedTimeout.ts
+++ b/src/lib/ConsolidatedTimeout.ts
@@ -7,7 +7,7 @@ type Timeout = ReturnType<typeof setTimeout>;
 export class ConsolidatedTimeout {
   private readonly callback: ExecutionCallback;
   private startTime: DateTime;
-  private timeouts = new Set<number>();
+  private timeoutMillis = new Set<number>();
   private runningTimeout?: Timeout;
 
   public constructor(callback: ExecutionCallback) {
@@ -30,22 +30,22 @@ export class ConsolidatedTimeout {
   public addTimeout(timeout: DurationLikeObject): RemoveTimeout {
     const timeoutMs = Duration.fromDurationLike(timeout).toMillis();
 
-    this.timeouts.add(timeoutMs);
+    this.timeoutMillis.add(timeoutMs);
     this.startNextTimeout();
 
     return () => {
-      this.timeouts.delete(timeoutMs);
+      this.timeoutMillis.delete(timeoutMs);
     };
   }
 
   private startNextTimeout(): void {
     this.clear();
 
-    if (this.timeouts.size === 0) {
+    if (this.timeoutMillis.size === 0) {
       return;
     }
 
-    const shortestTimeout = Math.min(...this.timeouts);
+    const shortestTimeout = Math.min(...this.timeoutMillis);
     const elapsedTime = this.startTime.diffNow().negate().toMillis();
     const ms = shortestTimeout - elapsedTime;
 

--- a/src/resource/getAsyncResource.ts
+++ b/src/resource/getAsyncResource.ts
@@ -1,7 +1,7 @@
 import { AsyncFn, FnParameters, GetAsyncResourceOptions } from "./types.js";
 import { defaultStorageKeyBuilder } from "../store/defaultStorageKeyBuilder.js";
 import { Store } from "../store/Store.js";
-import { AsyncResource, AsyncResourceOptions } from "./AsyncResource.js";
+import { AsyncResource } from "./AsyncResource.js";
 
 const emptyResource = new AsyncResource<undefined>(() =>
   Promise.resolve(undefined),
@@ -25,11 +25,7 @@ export function getAsyncResource<TValue, TParams extends FnParameters>(
   parameters: TParams | null,
   options: GetAsyncResourceOptions = {},
 ): AsyncResource<TValue | undefined> {
-  const { loaderId, tags, autoRefresh } = options;
-
-  const asyncResourceOptions: AsyncResourceOptions = {
-    ttl: autoRefresh,
-  };
+  const { loaderId, tags } = options;
 
   if (parameters === null) {
     return emptyResource;
@@ -43,8 +39,7 @@ export function getAsyncResource<TValue, TParams extends FnParameters>(
 
   const asyncResourceLoader = () => asyncFn(...parameters);
 
-  const resourceBuilder = () =>
-    new AsyncResource(asyncResourceLoader, asyncResourceOptions);
+  const resourceBuilder = () => new AsyncResource(asyncResourceLoader);
 
   return Store.default.getOrSet(storageKey, resourceBuilder, {
     tags: tags,

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -22,6 +22,7 @@ export type GetAsyncResourceOptions = {
 export type UseWatchResourceOptions = {
   keepValueWhileLoading?: boolean;
   useSuspense?: boolean;
+  autoRefresh?: DurationLikeObject;
 } & GetAsyncResourceOptions;
 
 export type NoSuspenseReturnType<T> = Readonly<

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -16,7 +16,6 @@ export type AsyncResourceState = "void" | "loading" | "loaded" | "error";
 export type GetAsyncResourceOptions = {
   loaderId?: string;
   tags?: Tags;
-  autoRefresh?: DurationLikeObject;
 };
 
 // useWatchResource types

--- a/src/resource/useWatchResourceValue.ts
+++ b/src/resource/useWatchResourceValue.ts
@@ -1,7 +1,8 @@
 import { AsyncResource } from "./AsyncResource.js";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useWatchObservableValue } from "../observable-value/useWatchObservableValue.js";
 import { UseWatchResourceOptions, UseWatchResourceResult } from "./types.js";
+import { hash } from "object-code";
 
 export const useWatchResourceValue = <
   T,
@@ -12,11 +13,21 @@ export const useWatchResourceValue = <
 ): UseWatchResourceResult<T, typeof options> => {
   type Result = UseWatchResourceResult<T, typeof options>;
 
-  const { keepValueWhileLoading = true, useSuspense = true } = options;
+  const {
+    keepValueWhileLoading = true,
+    useSuspense = true,
+    autoRefresh,
+  } = options;
 
   const observedValue = useWatchObservableValue(resource.value);
   const error = useWatchObservableValue(resource.error);
   const previousValue = useRef(observedValue);
+
+  useEffect(() => {
+    if (autoRefresh) {
+      return resource.addTTL(autoRefresh);
+    }
+  }, [hash(autoRefresh)]);
 
   void resource.load();
 


### PR DESCRIPTION
The autoRefresh option was ignored, when using `usePromise`. This change fixes this issue and adds the possibility, to configure multiple auto-refresh intervals for the same resource. If so, the shortest active interval will be used.